### PR TITLE
Add DXF output

### DIFF
--- a/boxmaker/__init__.py
+++ b/boxmaker/__init__.py
@@ -5,7 +5,7 @@ APP_VERSION = "2.1.0"
 WEBSITE_URL = "http://boxdesigner.connectionlab.org"
 
 def render(file_path,width,height,depth,thickness,
-           cut_width,notch_length,draw_bounding_box=False):
+           cut_width,notch_length,draw_bounding_box=False, file_type='pdf'):
     the_box = Box(file_path,width,height,depth,thickness,
-           			   cut_width,notch_length,draw_bounding_box)
+           			   cut_width,notch_length,draw_bounding_box, file_type)
     the_box.render()

--- a/boxmaker/box.py
+++ b/boxmaker/box.py
@@ -2,7 +2,13 @@ import logging, time
 from reportlab.pdfgen import canvas
 from reportlab.lib.units import mm
 from reportlab.lib.colors import black
+from boxmaker.dxf import DXFDoc
 import boxmaker
+
+DOC_CLASSES = {
+    'pdf': canvas.Canvas,
+    'dxf': DXFDoc
+}
 
 class Box():
     '''
@@ -27,7 +33,7 @@ class Box():
     '''
 
     def __init__(self,file_path,width,height,depth,thickness,
-           cut_width,notch_length,bounding_box):
+           cut_width,notch_length,bounding_box,file_type):
         self._logger = logging.getLogger(__name__)
         self._file_path = file_path
         self._desired_size = { 'w': float(width), 'h': float(height), 'd': float(depth) }
@@ -36,6 +42,7 @@ class Box():
         self._cut_width = float(cut_width)
         self._desired_notch_length = float(notch_length)
         self._bounding_box = bounding_box
+        self.doc_cls = DOC_CLASSES[file_type]
 
     def render(self):
         # set things up
@@ -138,7 +145,10 @@ class Box():
 
     def _initialize_document(self):
         # initialize the pdf file (based on layout of pieces)
-        self._doc = canvas.Canvas(self._file_path)
+        #self._doc = canvas.Canvas(self._file_path)
+        #self._doc = DXFDoc(self._file_path)
+        self._doc = self.doc_cls(self._file_path)
+
         self._doc.setPageSize( [self._doc_size['w']*mm, self._doc_size['h']*mm] )
         self._doc.setAuthor(boxmaker.APP_NAME+" "+boxmaker.APP_VERSION)
         self._doc.setStrokeColor(black)

--- a/boxmaker/dxf.py
+++ b/boxmaker/dxf.py
@@ -1,0 +1,202 @@
+# By Asher Blum, May 2016
+# Crude DXF writer; outputs lines and text
+
+FONT_SIZE = 8.0
+TEXT_WIDTH_FACTOR = 0.75
+
+class DXFDoc(object):
+  def __init__(self, filename):
+    self.chunks = []
+    self.filename = filename
+    self.add_head()
+    self.has_tail = False
+
+  def setPageSize(self, _):
+    pass
+
+  def setAuthor(self, _):
+    pass
+
+  def setStrokeColor(self, _):
+    pass
+
+  def setLineWidth(self, _):
+    pass
+
+  def drawString(self, x, y, st):
+    '''String must be free of metacharacters'''
+    pairs = [
+        (0, 'TEXT'),
+        (5, '4D'),
+        (8, 0),
+        (6, 'BYBLOCK'),
+        (10, x),
+        (20, y),
+        (30, 0),
+        (40, FONT_SIZE),
+        (41, TEXT_WIDTH_FACTOR),
+        (1, st),
+    ]
+    self._add_ent(pairs)
+
+  def rect(self, x, y, w, h):
+    points = [(x,y), (x+w, y), (x+w, y+h), (x, y+h)]
+    for i, pt in enumerate(points):
+      self._line((pt, points[(i+1)%4]))
+
+  def line(self, x0, y0, x1, y1):
+    self._line(((x0, y0), (x1, y1)))
+
+  def save(self):
+    if not self.has_tail:
+      self.add_tail()
+      self.has_tail = True
+    ofh = open(self.filename, 'w')
+    for chunk in self.chunks:
+      ofh.write(chunk)
+
+  #### end public API ###
+
+  def _line(self, line):
+    '''Given line=((x,y), (x,y)) add line'''
+    pairs = [
+        (0, 'LINE'),
+        (5, '4D'),
+        (8,  0),
+        (10, line[0][0]),
+        (20, line[0][1]),
+        (30, 0.0),
+        (11, line[1][0]),
+        (21, line[1][1]),
+        (31, 0.0),
+    ]
+    self._add_ent(pairs)
+
+  def _add_ent(self, pairs):
+    pairs = [('%3d' % a, str(b)) for a, b in pairs]
+    lines = ["\r\n".join(p) for p in pairs]
+    obuf = "\r\n".join(lines) + "\r\n"
+    self.chunks.append(obuf)
+
+  def add_tail(self):
+    '''DXF footer; place after last entity'''
+    pairs = [
+      (0, 'ENDSEC'),
+      (0, 'EOF'),
+    ]
+    self._add_ent(pairs)
+
+  def add_head(self):
+    '''Add a minimal DXF header. Entities should follow immediately'''
+    pairs = [
+      (0, 'SECTION'),
+      (2, 'HEADER'),
+      (9, '$ACADVER'),
+      (1, 'AC1009'),
+      (0, 'ENDSEC'),
+      (0, 'SECTION'),
+      (2, 'TABLES'),
+      (0, 'TABLE'),
+      (2, 'VPORT'),
+      (70, 1),
+      (0, 'VPORT'),
+      (2, '*ACTIVE'),
+      (70, 0),
+      (10, 0.0),
+      (20, 0.0),
+      (11, 1.0),
+      (21, 1.0),
+      (12, 344.1869158878504),
+      (22, 148.5),
+      (13, 0.0),
+      (23, 0.0),
+      (14, 10.0),
+      (24, 10.0),
+      (15, 10.0),
+      (25, 10.0),
+      (16, 0.0),
+      (26, 0.0),
+      (36, 1.0),
+      (17, -134.1869158878504),
+      (27, 0.0),
+      (37, 0.0),
+      (40, 385.2),
+      (41, 1.11214953271028),
+      (42, 50.0),
+      (43, 0.0),
+      (44, 0.0),
+      (50, 0.0),
+      (51, 0.0),
+      (71, 16),
+      (72, 1000),
+      (73, 1),
+      (74, 3),
+      (75, 0),
+      (76, 0),
+      (77, 0),
+      (78, 0),
+      (0, 'ENDTAB'),
+      (0, 'TABLE'),
+      (2, 'LTYPE'),
+      (70, 1),
+      (0, 'LTYPE'),
+      (2, 'CONTINUOUS'),
+      (70, 0),
+      (3, 'Solid line'),
+      (72, 65),
+      (73, 0),
+      (40, 0.0),
+      (0, 'ENDTAB'),
+      (0, 'TABLE'),
+      (2, 'LAYER'),
+      (70, 1),
+      (0, 'LAYER'),
+      (2, '0'),
+      (70, 0),
+      (62, 7),
+      (6, 'CONTINUOUS'),
+      (0, 'ENDTAB'),
+      (0, 'TABLE'),
+      (2, 'STYLE'),
+      (70, 1),
+      (0, 'STYLE'),
+      (2, 'STANDARD'),
+      (70, 0),
+      (40, 0.0),
+      (41, 1.0),
+      (50, 0.0),
+      (71, 0),
+      (42, 2.5),
+      (3, 'arial.ttf'),
+      (4, ''),
+      (0, 'ENDTAB'),
+      (0, 'TABLE'),
+      (2, 'VIEW'),
+      (70, 0),
+      (0, 'ENDTAB'),
+      (0, 'TABLE'),
+      (2, 'UCS'),
+      (70, 0),
+      (0, 'ENDTAB'),
+      (0, 'TABLE'),
+      (2, 'APPID'),
+      (70, 1),
+      (0, 'APPID'),
+      (2, 'ACAD'),
+      (70, 0),
+      (0, 'ENDTAB'),
+      (0, 'TABLE'),
+      (2, 'DIMSTYLE'),
+      (70, 1),
+      (0, 'ENDTAB'),
+      (0, 'ENDSEC'),
+      (0, 'SECTION'),
+      (2, 'BLOCKS'),
+      (0, 'ENDSEC'),
+      (0, 'SECTION'),
+      (2, 'ENTITIES'),
+    ]
+    self._add_ent(pairs)
+
+
+

--- a/server.py
+++ b/server.py
@@ -21,7 +21,8 @@ def index():
             logger.debug("Errors: "+error_str)
             return render_template('home.html', error=error_str)
         else:
-            box_name = _box_name()
+            file_type = request.form['file_type']
+            box_name = _box_name(file_type)
             logger.debug('Creating box '+box_name+"...")
             # convert it to millimeters
             measurements = ['width','height','depth','material_thickness','cut_width','notch_length']
@@ -37,22 +38,22 @@ def index():
             params['bounding_box'] = True if 'bounding_box' in request.form else False
             # now render it
             logger.info( request.remote_addr + " - " + box_name )
-            _render_box(box_name, params)
+            _render_box(box_name, file_type, params)
             return send_from_directory(BOX_TMP_DIR,box_name,as_attachment=True)
     else:
         return render_template("home.html",
             boxmaker_version = boxmaker.APP_VERSION)
 
-def _render_box(file_name, params):
-    pdf_file_path = os.path.join(BOX_TMP_DIR,file_name) 
-    boxmaker.render(pdf_file_path, 
+def _render_box(file_name, file_type, params):
+    out_file_path = os.path.join(BOX_TMP_DIR,file_name)
+    boxmaker.render(out_file_path,
         params['width'],params['height'],params['depth'],
         params['material_thickness'],params['cut_width'],params['notch_length'],
-        params['bounding_box']
+        params['bounding_box'], file_type
         )
 
-def _box_name():
-    return 'box-'+datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")+'.pdf'
+def _box_name(file_type):
+    return 'box-'+datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")+'.'+file_type
 
 def _validate_box_params():
     errors = []

--- a/templates/home.html
+++ b/templates/home.html
@@ -108,6 +108,18 @@
 				</div>
 			</div>
 
+			<div class="form-group">
+				<div class="row">
+					<label class="col-sm-3 control-label">File Type</label>
+          <div class="col-sm-6">
+                <select name="file_type" id="bm-filetype" class="form-control">
+                  <option value="pdf" selected>pdf</option>
+                  <option value="dxf">dxf</option>
+                </select>
+            </div>
+				</div>
+			</div>
+
 		</div>
 
 		<div class="form-group">


### PR DESCRIPTION
This patch lets you save as DXF, for import into a CAD program. Tested with DraftSight (free CAD for Linux).

A new dropdown in the GUI lets the user pick the output format.
