### PR TITLE
Add support for SVG files and continuous paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tmp/restart.txt
 tmp/test.pdf
 .idea
 venv
+.vscode

--- a/boxmaker/box.py
+++ b/boxmaker/box.py
@@ -4,11 +4,13 @@ from reportlab.pdfgen import canvas
 from reportlab.lib.units import mm
 from reportlab.lib.colors import black
 from boxmaker.dxf import DXFDoc
+from boxmaker.svg import SVGDoc
 import boxmaker
 
 DOC_CLASSES = {
     'pdf': canvas.Canvas,
-    'dxf': DXFDoc
+    'dxf': DXFDoc,
+    'svg': SVGDoc,
 }
 
 
@@ -31,9 +33,9 @@ class Box:
 
     <pre>
 
-              ( 5--------6 
-                |  w x d | 
-                8--------7 ) 
+              ( 5--------6
+                |  w x d |
+                8--------7 )
                 5========6
                 |  w x h |
                 |        |
@@ -84,7 +86,7 @@ class Box:
         self._doc.save()
 
     def _draw_top(self):
-        x0 = self._size['d'] + self._margin*2.0 
+        x0 = self._size['d'] + self._margin*2.0
         y0 = self._size['h']*2.0 + self._size['d'] + self._margin*4.0
         self._draw_horizontal_line(x0, y0,
                                    self._notch_length['w'], self._num_notches['w'],
@@ -149,7 +151,7 @@ class Box:
         self._draw_vertical_line(x0+self._size['w']-self._thickness, y0,
                                  self._notch_length['d'], self._num_notches['d'],
                                  self._thickness, -1*self._cut_width/2.0, False, True)
-      
+
     def _draw_right(self):
         x0 = self._size['d'] + self._size['w'] + self._margin*3.0
         y0 = self._size['h'] + self._margin*2.0
@@ -170,7 +172,7 @@ class Box:
 
     def _draw_front(self):
         x0 = self._size['d'] + self._margin*2.0
-        y0 = self._size['h'] + self._size['d'] + self._margin*3.0    
+        y0 = self._size['h'] + self._size['d'] + self._margin*3.0
         self._draw_horizontal_line(x0, y0,
                                    self._notch_length['w'], self._num_notches['w'],
                                    self._thickness, self._cut_width/2.0, False, False)

--- a/boxmaker/box.py
+++ b/boxmaker/box.py
@@ -5,10 +5,12 @@ from reportlab.lib.units import mm
 from reportlab.lib.colors import black
 from boxmaker.dxf import DXFDoc
 from boxmaker.svg import SVGDoc
+from boxmaker.pdf import PDFDoc
+from boxmaker.pathbuilder import PathBuilder, Point
 import boxmaker
 
 DOC_CLASSES = {
-    'pdf': canvas.Canvas,
+    'pdf': PDFDoc,
     'dxf': DXFDoc,
     'svg': SVGDoc,
 }
@@ -63,6 +65,7 @@ class Box:
         self._bounding_box = bounding_box
         self._doc_cls = DOC_CLASSES[file_type]
         self._tray = tray
+        self.paths = PathBuilder()
 
     def render(self):
         # set things up
@@ -83,6 +86,8 @@ class Box:
         # 6. a W X D side (the top)
         if not self._tray:
             self._draw_top()        # and write out the file
+        self.paths.join_paths()
+        self.paths.emit_paths(self._doc)
         self._doc.save()
 
     def _draw_top(self):
@@ -297,4 +302,4 @@ class Box:
             y = y+notch_width
 
     def _draw_line(self, from_x, from_y, to_x, to_y):
-        self._doc.line(from_x*mm, from_y*mm, to_x*mm, to_y*mm)
+        self.paths.add_segment(from_x*mm, from_y*mm, to_x*mm, to_y*mm)

--- a/boxmaker/box.py
+++ b/boxmaker/box.py
@@ -1,6 +1,5 @@
 import logging
 import time
-from reportlab.pdfgen import canvas
 from reportlab.lib.units import mm
 from reportlab.lib.colors import black
 from boxmaker.dxf import DXFDoc

--- a/boxmaker/dxf.py
+++ b/boxmaker/dxf.py
@@ -46,8 +46,15 @@ class DXFDoc(object):
         for i, pt in enumerate(points):
             self._line((pt, points[(i+1) % 4]))
 
-    def line(self, x0, y0, x1, y1):
-        self._line(((x0, y0), (x1, y1)))
+    def drawClosedPath(self, p):
+        # just draw all the segments
+        start = p[0]
+        for end in p[1:]:
+            self._line((start, end))
+
+    def drawOpenPath(self, p):
+        # same as the closed path ones since we're just drawing segments
+        self.drawClosedPath(p)
 
     def save(self):
         if not self.has_tail:

--- a/boxmaker/pathbuilder.py
+++ b/boxmaker/pathbuilder.py
@@ -1,0 +1,94 @@
+class Point(object):
+    """
+    Point is a class that keeps an x-y pair of possibly-floating-point values and allows approximate comparison of those
+    points by rounding them to only two decimal places without actually affecting their full precision.
+    """
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+    def __hash__(self):
+        return hash("{:.2f}{:.2f}".format(self.x, self.y))
+
+    def __eq__(self, other):
+        return self.__hash__() == other.__hash__()
+
+
+class PathBuilder(object):
+    """
+    The PathBuilder object collects a set of add_segment calls and then can reduce those to the
+    smallest set of connected paths, closing them if possible.
+    """
+    def __init__(self):
+        self.paths = []
+        self.firsts = set()
+
+    def add_segment(self, x0, y0, x1, y1):
+        p1 = Point(x0, y0)
+        p2 = Point(x1, y1)
+        # make a line segment
+        seg = [p1, p2]
+        # but if two segments are known to start with the same value, reverse the new one
+        if p1 in self.firsts:
+            seg = [p2, p1]
+        self.paths.append(seg)
+        # We may still have overlapping firsts but that's OK; we're just using this to
+        # accelerate some decision-making
+        self.firsts.add(seg[0])
+
+    def emit_paths(self, doc):
+        # for p in self.paths:
+        #     pathfunc(p)
+        for p in self.paths:
+            pointsonly = [(pt.x, pt.y) for pt in p]
+            if p[0] == p[-1]:
+                doc.drawClosedPath(pointsonly)
+            else:
+                doc.drawOpenPath(pointsonly)
+
+    def join_paths(self):
+        """ Call _join_paths_1 repeatedly until it doesn't change any more. """
+        while True:
+            count = len(self.paths)
+            paths = self._join_paths_1()
+            self.paths = paths
+            if len(paths) == count:
+                break
+
+    def _join_paths_1(self):
+        """
+        Create a new copy of the paths that concatenates some of them together if they can be joined.
+        This doesn't attempt to find all paths, only to make the output list of paths shorter.
+
+        Algorithm:
+            While the list is not empty:
+                Pop the last path off the list.
+                Attempt to find a path elsewhere on the list to append it to, either as-is or reversed.
+                If found:
+                    remove the matching path from the input list,
+                    concatenate the other one
+                    put the combined result into the output.
+                Else:
+                    put the popped path into the output.
+            Return the new list
+        """
+        oldpaths = self.paths[:]
+        newpaths = []
+        while len(oldpaths):
+            start = -1
+            it = oldpaths.pop()
+            for pi in range(len(oldpaths)):
+                if oldpaths[pi][-1] == it[0]:
+                    start = pi
+                    break
+                if oldpaths[pi][-1] == it[-1]:
+                    start = pi
+                    it.reverse()
+                    break
+            if start == -1:
+                newpaths.append(it)
+            else:
+                newpaths.append(oldpaths[start] + it[1:])
+                del oldpaths[start]
+        return newpaths
+

--- a/boxmaker/pathbuilder.py
+++ b/boxmaker/pathbuilder.py
@@ -37,8 +37,10 @@ class PathBuilder(object):
         self.firsts.add(seg[0])
 
     def emit_paths(self, doc):
-        # for p in self.paths:
-        #     pathfunc(p)
+        """
+        Walk the list of paths and emit them as either closed or open depending
+        on if the endpoints are the same point.
+        """
         for p in self.paths:
             pointsonly = [(pt.x, pt.y) for pt in p]
             if p[0] == p[-1]:

--- a/boxmaker/pdf.py
+++ b/boxmaker/pdf.py
@@ -1,18 +1,13 @@
 # By Kent Quirk, April 2018
-# PDF writer; outputs lines and text
+# PDF writer
 
-# Although SVG is an XML-based language, XML manipulation is annoyingly complicated for what we need
-# to do here, so we're just going to treat set things up with a template and embed strings.
-
-# This system exists generate SVG files -- in particular to use with the Glowforge laser cutter. One thing that
-# makes using the Glowforge UI work better is for SVGs to use closed paths rather than a semi-random selection of
-# lines. Consequently, what this driver does is collect all of the line commands and record them; on the
-# save call it concatenates them together into a set of paths.
+# The dxf object was originally designed to emulate canvas.Canvas -- but that has proved a little too limiting.
+# So instead of pdfs rendering directly to canvas.Canvas, we have specific drivers for different file types.
+# This file implements the pdf-specific rendering.
 
 from reportlab.pdfgen import canvas
 import reportlab.lib.colors as colors
 from string import Template
-
 
 class PDFDoc(object):
 

--- a/boxmaker/pdf.py
+++ b/boxmaker/pdf.py
@@ -1,0 +1,56 @@
+# By Kent Quirk, April 2018
+# PDF writer; outputs lines and text
+
+# Although SVG is an XML-based language, XML manipulation is annoyingly complicated for what we need
+# to do here, so we're just going to treat set things up with a template and embed strings.
+
+# This system exists generate SVG files -- in particular to use with the Glowforge laser cutter. One thing that
+# makes using the Glowforge UI work better is for SVGs to use closed paths rather than a semi-random selection of
+# lines. Consequently, what this driver does is collect all of the line commands and record them; on the
+# save call it concatenates them together into a set of paths.
+
+from reportlab.pdfgen import canvas
+import reportlab.lib.colors as colors
+from string import Template
+
+
+class PDFDoc(object):
+
+    def __init__(self, filename):
+        self.canvas = canvas.Canvas(filename)
+
+    def setPageSize(self, pageSize):
+        self.canvas.setPageSize(pageSize)
+
+    def setAuthor(self, author):
+        self.canvas.setAuthor(author)
+
+    def setStrokeColor(self, col):
+        self.canvas.setStrokeColor(col)
+
+    def setLineWidth(self, lw):
+        self.canvas.setLineWidth(lw)
+
+    def drawString(self, x, y, st):
+        self.canvas.drawString(x, y, st)
+
+    def rect(self, x, y, w, h):
+        self.canvas.rect(x, y, w, h)
+
+    def drawClosedPath(self, p):
+        path = self.canvas.beginPath()
+        path.moveTo(p[0][0], p[0][1])
+        for pt in p[1:-1]:
+            path.lineTo(pt[0], pt[1])
+        path.close()
+        self.canvas.drawPath(path)
+
+    def drawOpenPath(self, p):
+        path = self.canvas.beginPath()
+        path.moveTo(p[0][0], p[0][1])
+        for pt in p[1:]:
+            path.lineTo(pt[0], pt[1])
+        self.canvas.drawPath(path)
+
+    def save(self):
+        self.canvas.save()

--- a/boxmaker/svg.py
+++ b/boxmaker/svg.py
@@ -1,0 +1,159 @@
+# By Kent Quirk, April 2018
+# SVG writer; outputs lines and text
+
+# Although SVG is an XML-based language, XML manipulation is annoyingly complicated for what we need
+# to do here, so we're just going to treat set things up with a template and embed strings.
+
+# This system exists generate SVG files -- in particular to use with the Glowforge laser cutter. One thing that
+# makes using the Glowforge UI work better is for SVGs to use closed paths rather than a semi-random selection of
+# lines. Consequently, what this driver does is collect all of the line commands and record them; on the
+# save call it concatenates them together into a set of paths.
+
+import reportlab.lib.colors as colors
+from string import Template
+
+tmpl_svg = Template("""<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg width="${pixel_width}px" height="${pixel_height}px" version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xml:space="preserve"
+    xmlns:serif="http://www.serif.com/"
+    style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:1.5;">
+${contents}
+</svg>
+""")
+
+tmpl_path = Template("""        <path d="${path}" style="fill:none;stroke:${stroke_color};stroke-width:${stroke_pixels}px;"/>
+""")
+
+tmpl_rect = Template("""        <rect x="${x}" y="${y}" width="${w}" height="${h}"/>
+""")
+
+
+class SVGDoc(object):
+
+    def __init__(self, filename):
+        self.comments = []
+        self.elements = []
+        self.paths = []
+        self.firsts = set()
+        self.filename = filename
+        self.strokeColor = "black"
+        self.lineWidth = 0.5  # default is mm so we need to convert
+        self.pageSize = [0, 0]
+        self.author = ''
+
+    def setPageSize(self, pageSize):
+        self.pageSize = pageSize
+
+    def setAuthor(self, author):
+        self.author = author
+
+    def setStrokeColor(self, col):
+        self.strokeColor = col
+
+    def setLineWidth(self, lw):
+        self.lineWidth = lw
+
+    def drawString(self, x, y, st):
+        # String must be free of metacharacters
+        self.comments.append((x, y, st))
+
+    def rect(self, x, y, w, h):
+        self.elements.append(tmpl_rect.substitute(dict(x=self._sc(x), y=self._sc(y), w=self._sc(w), h=self._sc(h))))
+
+    def line(self, x0, y0, x1, y1):
+        self._line(x0, y0, x1, y1)
+
+    def beginPath(self):
+        pass
+
+    def moveTo(self, x, y):
+        pass
+
+    def lineTo(self, x, y):
+        pass
+
+    def drawPath(self):
+        pass
+
+    def save(self):
+        self._join_paths()
+        self._generateElements()
+        s = ''.join([e for e in self.elements])
+        pgw, pgh = self._sc(self.pageSize[0]), self._sc(self.pageSize[1])
+        svg = tmpl_svg.substitute(dict(
+            pixel_width=pgw,
+            pixel_height=pgh,
+            contents=s))
+        ofh = open(self.filename, 'w')
+        ofh.write(svg)
+        ofh.close()
+
+
+    # end public API
+
+    def _sc(self, v):
+        "converts from mm to pixels as a numeric string"
+        return "{:.1f}".format(v)# * 96 / 25.4)
+
+    def _col(self, color):
+        "generates a CSS color from a reportlab color"
+        return '#'+color.hexval()[2:]
+
+    def _generateElements(self):
+        for p in self.paths:
+            s = ''
+            if p[0] == p[-1]:
+                # generate closed path
+                s = "M{},{}".format(p[0][0], p[0][1])
+                s += ''.join(["L{},{}".format(pt[0], pt[1]) for pt in p[1:-1]])
+                s += 'Z'
+            else:
+                # generate open path
+                s = "M{},{}".format(p[0][0], p[0][1])
+                s += ''.join(["L{},{}".format(pt[0], pt[1]) for pt in p[1:]])
+            self.elements.append(tmpl_path.substitute(dict(
+                path=s,
+                stroke_color=self._col(self.strokeColor),
+                stroke_pixels=self._sc(self.lineWidth)
+                )))
+
+    def _join_paths_1(self):
+        oldpaths = self.paths[:]
+        newpaths = []
+        while len(oldpaths):
+            start = -1
+            it = oldpaths.pop()
+            for pi in range(len(oldpaths)):
+                if oldpaths[pi][-1] == it[0]:
+                    start = pi
+                    break
+                if oldpaths[pi][-1] == it[-1]:
+                    start = pi
+                    it.reverse()
+                    break
+            if start == -1:
+                newpaths.append(it)
+            else:
+                newpaths.append(oldpaths[start] + it[1:])
+                del oldpaths[start]
+        return newpaths
+
+    def _join_paths(self):
+        while True:
+            count = len(self.paths)
+            paths = self._join_paths_1()
+            self.paths = paths
+            if len(paths) == count:
+                break
+
+    def _line(self, x0, y0, x1, y1):
+        p1 = (self._sc(x0), self._sc(y0))
+        p2 = (self._sc(x1), self._sc(y1))
+        seg = [p1, p2]
+        if p1 in self.firsts:
+            seg = [p2, p1]
+        self.paths.append(seg)
+        self.firsts.add(seg[0])

--- a/templates/home.html
+++ b/templates/home.html
@@ -28,8 +28,8 @@
 			<div class="row">
 				<label class="col-sm-3 control-label">Dimensions</label>
 				<div class="col-sm-9">
-					<input class="form-control" type="text" name="width" value="4"/> x 
-					<input class="form-control" type="text" name="depth" value="5" /> x 
+					<input class="form-control" type="text" name="width" value="4"/> x
+					<input class="form-control" type="text" name="depth" value="5" /> x
 					<input class="form-control" type="text" name="height" value="6" />
 					&nbsp;
 					<span class="glyphicon glyphicon-question-sign bm-btn-popover" data-toggle="popover" data-content="The width x depth x height of your box (outer dimension)."></span>
@@ -50,12 +50,12 @@
 
 		<div class="form-group">
 			<div class="row">
-        <div class="col-sm-offset-3 col-sm-9"> 
+        <div class="col-sm-offset-3 col-sm-9">
     		  [ <a href="#" onClick="$('#bm-create-advanced').slideToggle();return false;">advanced options</a> ]
     		</div>
     	</div>
     </div>
-	    
+
     <div id="bm-create-advanced" style="display:none">
 
 			<div class="form-group">
@@ -68,9 +68,9 @@
 							Auto
 						</label>
 						&nbsp;
-						<span class="glyphicon glyphicon-question-sign bm-btn-popover" data-toggle="popover" data-content="The length of each notch. If you don't care, just leave the auto checkbox as is.  A good 
-			            general rule is two or three times the material depth. Note that this parameter is used 
-			            as a suggestion only - the program will adjust the notch length so that the geometry of 
+						<span class="glyphicon glyphicon-question-sign bm-btn-popover" data-toggle="popover" data-content="The length of each notch. If you don't care, just leave the auto checkbox as is.  A good
+			            general rule is two or three times the material depth. Note that this parameter is used
+			            as a suggestion only - the program will adjust the notch length so that the geometry of
 			            the box comes out correctly."></span>
 					</div>
 				</div>
@@ -82,12 +82,12 @@
 					<div class="col-sm-9">
 						<input class="form-control" type="text" name="cut_width" value="0" />
 						&nbsp;
-						<span class="glyphicon glyphicon-question-sign bm-btn-popover" data-toggle="popover" data-content="The width of material removed by the laser. We assume that the beam cuts symmetrically 
+						<span class="glyphicon glyphicon-question-sign bm-btn-popover" data-toggle="popover" data-content="The width of material removed by the laser. We assume that the beam cuts symmetrically
 				        around the cutting line but that it has some finite width. For example, if a non-zero cut
-			            width is specified, the notches will be slightly exaggerated so that the notches fit more 
-			            snugly together. A value of zero is usually safe but loose-fitting. The cut width must be 
-			            experimentally determined, as it is a function of the material, laser speed/power parameters, 
-			            etc. Reasonable values for 1/8 inch acrylic are .004 inches to .008 inches. If the cut width is 
+			            width is specified, the notches will be slightly exaggerated so that the notches fit more
+			            snugly together. A value of zero is usually safe but loose-fitting. The cut width must be
+			            experimentally determined, as it is a function of the material, laser speed/power parameters,
+			            etc. Reasonable values for 1/8 inch acrylic are .004 inches to .008 inches. If the cut width is
 			            set too large, the box will not fit together snugly."></span>
 					</div>
 				</div>
@@ -101,7 +101,7 @@
 						  <input type="checkbox" name="bounding_box"/> Draw bounding box
 						</label>
 						&nbsp;
-						<span class="glyphicon glyphicon-question-sign bm-btn-popover" data-toggle="popover" data-content="Having problems with DXF imports?  Choose to add a bounding box around the whole box design 
+						<span class="glyphicon glyphicon-question-sign bm-btn-popover" data-toggle="popover" data-content="Having problems with DXF imports?  Choose to add a bounding box around the whole box design
 			            and then you can size the entire thing correctly once you import it."></span>
 					</div>
 				</div>
@@ -114,6 +114,7 @@
             <select name="file_type" id="bm-filetype" class="form-control">
               <option value="pdf" selected>pdf</option>
               <option value="dxf">dxf</option>
+              <option value="svg">svg</option>
             </select>
           </div>
 				</div>
@@ -135,7 +136,7 @@
 
 		<div class="form-group">
 			<div class="row">
-        <div class="col-sm-offset-3 col-sm-9"> 
+        <div class="col-sm-offset-3 col-sm-9">
 				  <button type="submit" class="btn btn-default">Design It!</button>
 				</div>
 			</div>


### PR DESCRIPTION
This fork does the following things:

## At the user level:

* Supports writing to SVG files directly; PDF files are equivalent but add an extra step when using these box files with a Glowforge laser cutter.

* Generates the outlines as continuous paths. One of the problems with using the existing box data files as generated is that the outlines of the pieces are emitted as disconnected line segments that are out of order. This causes problems with selecting and moving them.  By generating the outlines as a single continuous path, this allows them to be individually selected easily, and probably removes the need for the outline path.

## At the technical level:

The original code created DXF files by emulating the behavior of the PDF generator's canvas. But proper implementation here meant that we needed to pull out PDF into its own driver and create an SVG driver as well. So there are now source files (effectively drivers) for each of svg, pdf, and dxf. 

The other thing this does is defer line segment creation. The line function no longer generates a line, it simply stores all the line segments in a list. Later, when the time comes to save them, it first consolidates them into connected closed paths, and then generates the paths into the output by calling a new path builder function in each driver.

It should be noted that I don't know anything about DXF formats, so the DXF driver still generates line segments rather than a path. The difference is that now the segments are in connected order.